### PR TITLE
fixed cia-line

### DIFF
--- a/drivers/cia-line.c
+++ b/drivers/cia-line.c
@@ -43,7 +43,7 @@ static void AcknowledgeTimerIRQ(void) {
 }
 
 static void LineCounterHandler(List_t *tasks) {
-  AcknowledgeTimerIRQ();
+  (void)SampleICR(CIAB, 0x00);
 
   if (listLIST_IS_EMPTY(tasks))
     return;

--- a/drivers/cia-line.c
+++ b/drivers/cia-line.c
@@ -35,6 +35,8 @@ static void SetAlarm(uint32_t line) {
 }
 
 static void LineCounterHandler(List_t *tasks) {
+  /* CIA requires the interrupt to be acknowledged by the handler.
+   * This is done by reading the value in Interrupt Control Register */
   (void)SampleICR(CIAB, 0x00);
 
   if (listLIST_IS_EMPTY(tasks))

--- a/drivers/cia-line.c
+++ b/drivers/cia-line.c
@@ -34,14 +34,6 @@ static void SetAlarm(uint32_t line) {
   BCLR(*ciacrb, CIACRAB_TODIN);
 }
 
-/* CIA requires the interrupt to be acknowledged by the handler.
- * This is done by reading the value in Interrupt Control Register */
-static void AcknowledgeTimerIRQ(void) {
-  CIA_t cia = CIAB;
-  volatile uint8_t * ciab = &cia->_ciaicr;
-  uint8_t read = *ciab; 
-}
-
 static void LineCounterHandler(List_t *tasks) {
   (void)SampleICR(CIAB, 0x00);
 

--- a/drivers/cia-line.c
+++ b/drivers/cia-line.c
@@ -34,7 +34,17 @@ static void SetAlarm(uint32_t line) {
   BCLR(*ciacrb, CIACRAB_TODIN);
 }
 
+/* CIA requires the interrupt to be acknowledged by the handler.
+ * This is done by reading the value in Interrupt Control Register */
+static void AcknowledgeTimerIRQ(void) {
+	CIA_t cia = CIAB;
+	volatile uint8_t * ciab = &cia->_ciaicr;
+	uint8_t read = *ciab; 
+}
+
 static void LineCounterHandler(List_t *tasks) {
+  AcknowledgeTimerIRQ();
+
   if (listLIST_IS_EMPTY(tasks))
     return;
 

--- a/drivers/cia-line.c
+++ b/drivers/cia-line.c
@@ -37,9 +37,9 @@ static void SetAlarm(uint32_t line) {
 /* CIA requires the interrupt to be acknowledged by the handler.
  * This is done by reading the value in Interrupt Control Register */
 static void AcknowledgeTimerIRQ(void) {
-	CIA_t cia = CIAB;
-	volatile uint8_t * ciab = &cia->_ciaicr;
-	uint8_t read = *ciab; 
+  CIA_t cia = CIAB;
+  volatile uint8_t * ciab = &cia->_ciaicr;
+  uint8_t read = *ciab; 
 }
 
 static void LineCounterHandler(List_t *tasks) {


### PR DESCRIPTION
`LineCounterWait` wasn't working properly before. CIA has to be informed that the interrupt has was handled by an ISR in order to set IRQ low. This pull request fixes that by making the ISR read data from *Interrupt Control Register* of CIA which informs it the interrupt was handled.