### PR TITLE
Fix bug with cursor drawing

### DIFF
--- a/examples/console/console.c
+++ b/examples/console/console.c
@@ -60,7 +60,7 @@ static void ConsoleDrawChar(short x, short y, uint8_t c) {
 void ConsoleDrawCursor(void) {
   unsigned char *dst = cons.bitmap->planes[0];
   short dwidth = cons.bitmap->bytesPerRow;
-  short h = cons.bitmap->height - 1;
+  short h = cons.font->height - 1;
 
   dst += cons.bitmap->width * cons.cursor.y + cons.cursor.x;
 


### PR DESCRIPTION
Before whole column under cursor was highlighted. Now only one character where cursor is is highlighted.