### PR TITLE
Fix memory allocator

### DIFF
--- a/FreeRTOS/portable/m68k-amiga/heap.c
+++ b/FreeRTOS/portable/m68k-amiga/heap.c
@@ -59,6 +59,7 @@ static void *_pvPortMalloc(int size, memory_t m) {
           /* Insert the block on free list. */
           succ->next = curr->next;
           curr->next = succ;
+          curr->size = size;
         }
         /* Decrease the amount of available memory. */
         m->totalFree -= size + BLOCK_SIZE;


### PR DESCRIPTION
There was a nasty bug in the memory allocator. When a free block was splitted its size wasn't updated to represent a new state. Freeing some of this bugged blocks resulted in releasing other blocks.